### PR TITLE
Add initial restaurant API with tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,12 +72,17 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+                <dependency>
+                        <groupId>org.springframework.security</groupId>
+                        <artifactId>spring-security-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>test</scope>
+                </dependency>
+        </dependencies>
 
 	<build>
 		<plugins>

--- a/src/main/java/com/example/nagoyameshi/controller/RestaurantController.java
+++ b/src/main/java/com/example/nagoyameshi/controller/RestaurantController.java
@@ -1,0 +1,23 @@
+package com.example.nagoyameshi.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.nagoyameshi.entity.Restaurant;
+import com.example.nagoyameshi.service.RestaurantService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class RestaurantController {
+    private final RestaurantService restaurantService;
+
+    @GetMapping("/restaurants")
+    public List<Restaurant> getRestaurants(@RequestParam(name = "name", required = false) String name) {
+        return restaurantService.getRestaurants(name);
+    }
+}

--- a/src/main/java/com/example/nagoyameshi/entity/Restaurant.java
+++ b/src/main/java/com/example/nagoyameshi/entity/Restaurant.java
@@ -1,0 +1,28 @@
+package com.example.nagoyameshi.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "restaurants")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Restaurant {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private String description;
+}

--- a/src/main/java/com/example/nagoyameshi/repository/RestaurantRepository.java
+++ b/src/main/java/com/example/nagoyameshi/repository/RestaurantRepository.java
@@ -1,0 +1,11 @@
+package com.example.nagoyameshi.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.nagoyameshi.entity.Restaurant;
+
+public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
+    List<Restaurant> findByNameContaining(String name);
+}

--- a/src/main/java/com/example/nagoyameshi/service/RestaurantService.java
+++ b/src/main/java/com/example/nagoyameshi/service/RestaurantService.java
@@ -1,0 +1,9 @@
+package com.example.nagoyameshi.service;
+
+import java.util.List;
+
+import com.example.nagoyameshi.entity.Restaurant;
+
+public interface RestaurantService {
+    List<Restaurant> getRestaurants(String name);
+}

--- a/src/main/java/com/example/nagoyameshi/service/RestaurantServiceImpl.java
+++ b/src/main/java/com/example/nagoyameshi/service/RestaurantServiceImpl.java
@@ -1,0 +1,24 @@
+package com.example.nagoyameshi.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.example.nagoyameshi.entity.Restaurant;
+import com.example.nagoyameshi.repository.RestaurantRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RestaurantServiceImpl implements RestaurantService {
+    private final RestaurantRepository restaurantRepository;
+
+    @Override
+    public List<Restaurant> getRestaurants(String name) {
+        if (name == null || name.isBlank()) {
+            return restaurantRepository.findAll();
+        }
+        return restaurantRepository.findByNameContaining(name);
+    }
+}

--- a/src/test/java/com/example/nagoyameshi/controller/RestaurantControllerTest.java
+++ b/src/test/java/com/example/nagoyameshi/controller/RestaurantControllerTest.java
@@ -1,0 +1,39 @@
+package com.example.nagoyameshi.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.example.nagoyameshi.entity.Restaurant;
+import com.example.nagoyameshi.service.RestaurantService;
+
+@WebMvcTest(RestaurantController.class)
+class RestaurantControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RestaurantService restaurantService;
+
+    @Test
+    @DisplayName("GET /restaurants returns restaurants")
+    void testGetRestaurants() throws Exception {
+        Restaurant r = Restaurant.builder().id(1L).name("Nagoya Ramen").description("desc").build();
+        when(restaurantService.getRestaurants("Ramen")).thenReturn(List.of(r));
+
+        mockMvc.perform(get("/restaurants").param("name", "Ramen"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value("Nagoya Ramen"));
+    }
+}

--- a/src/test/java/com/example/nagoyameshi/repository/RestaurantRepositoryTest.java
+++ b/src/test/java/com/example/nagoyameshi/repository/RestaurantRepositoryTest.java
@@ -1,0 +1,32 @@
+package com.example.nagoyameshi.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import com.example.nagoyameshi.entity.Restaurant;
+
+@DataJpaTest
+class RestaurantRepositoryTest {
+
+    @Autowired
+    private RestaurantRepository restaurantRepository;
+
+    @Test
+    @DisplayName("findByNameContaining returns matching restaurants")
+    void testFindByNameContaining() {
+        Restaurant r1 = Restaurant.builder().name("Nagoya Ramen").description("desc").build();
+        Restaurant r2 = Restaurant.builder().name("Tokyo Ramen").description("desc").build();
+        restaurantRepository.saveAll(List.of(r1, r2));
+
+        List<Restaurant> result = restaurantRepository.findByNameContaining("Nagoya");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getName()).isEqualTo("Nagoya Ramen");
+    }
+}


### PR DESCRIPTION
## Summary
- implement simple `Restaurant` entity and repository
- add service and controller with `/restaurants` endpoint
- include integration and web MVC tests
- configure H2 database for tests

## Testing
- `./mvnw -q test` *(fails: wget failed to fetch maven)*

------
https://chatgpt.com/codex/tasks/task_e_684acf0412d0832793a934235b9969d5