### PR TITLE
Add Spring Security user registration

### DIFF
--- a/src/main/java/com/example/nagoyameshi/config/SecurityConfig.java
+++ b/src/main/java/com/example/nagoyameshi/config/SecurityConfig.java
@@ -1,0 +1,38 @@
+package com.example.nagoyameshi.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+import com.example.nagoyameshi.service.UserServiceImpl;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final UserServiceImpl userService;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf().disable()
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/register", "/verify").permitAll()
+                .anyRequest().permitAll()
+            )
+            .userDetailsService(userService)
+            .formLogin(Customizer.withDefaults());
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/example/nagoyameshi/controller/AuthController.java
+++ b/src/main/java/com/example/nagoyameshi/controller/AuthController.java
@@ -1,0 +1,33 @@
+package com.example.nagoyameshi.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.nagoyameshi.dto.RegisterRequest;
+import com.example.nagoyameshi.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+    private final UserService userService;
+
+    @PostMapping("/register")
+    public ResponseEntity<Void> register(@Validated @RequestBody RegisterRequest request) {
+        userService.register(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/verify")
+    public ResponseEntity<Void> verify(@RequestParam("token") String token) {
+        boolean result = userService.verify(token);
+        return result ? ResponseEntity.ok().build() : ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+    }
+}

--- a/src/main/java/com/example/nagoyameshi/dto/RegisterRequest.java
+++ b/src/main/java/com/example/nagoyameshi/dto/RegisterRequest.java
@@ -1,0 +1,15 @@
+package com.example.nagoyameshi.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class RegisterRequest {
+    @Email
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    private String password;
+}

--- a/src/main/java/com/example/nagoyameshi/entity/User.java
+++ b/src/main/java/com/example/nagoyameshi/entity/User.java
@@ -1,0 +1,36 @@
+package com.example.nagoyameshi.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    private String role;
+
+    private boolean enabled;
+
+    private String verificationCode;
+}

--- a/src/main/java/com/example/nagoyameshi/repository/UserRepository.java
+++ b/src/main/java/com/example/nagoyameshi/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.example.nagoyameshi.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.nagoyameshi.entity.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+    Optional<User> findByVerificationCode(String code);
+}

--- a/src/main/java/com/example/nagoyameshi/service/ConsoleEmailService.java
+++ b/src/main/java/com/example/nagoyameshi/service/ConsoleEmailService.java
@@ -1,0 +1,14 @@
+package com.example.nagoyameshi.service;
+
+import org.springframework.stereotype.Service;
+
+import com.example.nagoyameshi.entity.User;
+
+@Service
+public class ConsoleEmailService implements EmailService {
+    @Override
+    public void sendVerificationEmail(User user) {
+        System.out.println("Send verification email to " + user.getEmail()
+                + " token=" + user.getVerificationCode());
+    }
+}

--- a/src/main/java/com/example/nagoyameshi/service/EmailService.java
+++ b/src/main/java/com/example/nagoyameshi/service/EmailService.java
@@ -1,0 +1,7 @@
+package com.example.nagoyameshi.service;
+
+import com.example.nagoyameshi.entity.User;
+
+public interface EmailService {
+    void sendVerificationEmail(User user);
+}

--- a/src/main/java/com/example/nagoyameshi/service/UserService.java
+++ b/src/main/java/com/example/nagoyameshi/service/UserService.java
@@ -1,0 +1,9 @@
+package com.example.nagoyameshi.service;
+
+import com.example.nagoyameshi.dto.RegisterRequest;
+import com.example.nagoyameshi.entity.User;
+
+public interface UserService {
+    User register(RegisterRequest request);
+    boolean verify(String token);
+}

--- a/src/main/java/com/example/nagoyameshi/service/UserServiceImpl.java
+++ b/src/main/java/com/example/nagoyameshi/service/UserServiceImpl.java
@@ -1,0 +1,67 @@
+package com.example.nagoyameshi.service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import com.example.nagoyameshi.dto.RegisterRequest;
+import com.example.nagoyameshi.entity.User;
+import com.example.nagoyameshi.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService, UserDetailsService {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final EmailService emailService;
+
+    @Override
+    public User register(RegisterRequest request) {
+        if (userRepository.findByEmail(request.getEmail()).isPresent()) {
+            throw new IllegalArgumentException("Email already registered");
+        }
+        String encoded = passwordEncoder.encode(request.getPassword());
+        String token = UUID.randomUUID().toString();
+        User user = User.builder()
+                .email(request.getEmail())
+                .password(encoded)
+                .role("USER")
+                .enabled(false)
+                .verificationCode(token)
+                .build();
+        userRepository.save(user);
+        emailService.sendVerificationEmail(user);
+        return user;
+    }
+
+    @Override
+    public boolean verify(String token) {
+        Optional<User> opt = userRepository.findByVerificationCode(token);
+        if (opt.isEmpty()) {
+            return false;
+        }
+        User user = opt.get();
+        user.setEnabled(true);
+        user.setVerificationCode(null);
+        userRepository.save(user);
+        return true;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+        return org.springframework.security.core.userdetails.User.withUsername(user.getEmail())
+                .password(user.getPassword())
+                .roles(user.getRole())
+                .disabled(!user.isEnabled())
+                .build();
+    }
+}

--- a/src/test/java/com/example/nagoyameshi/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/nagoyameshi/controller/AuthControllerTest.java
@@ -1,0 +1,32 @@
+package com.example.nagoyameshi.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.example.nagoyameshi.service.UserService;
+
+@WebMvcTest(AuthController.class)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    @Test
+    @DisplayName("POST /register returns 200")
+    void testRegister() throws Exception {
+        String json = "{\"email\":\"a@example.com\",\"password\":\"pass\"}";
+        mockMvc.perform(post("/register").contentType(MediaType.APPLICATION_JSON).content(json))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
## Summary
- add `User` entity and `UserRepository`
- implement `UserService` with email verification
- wire up `SecurityConfig`
- provide `AuthController` endpoints for registration and verification
- test registration endpoint

## Testing
- `mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684af7534b3c8327811f4ebcc9cb7972