### PR TITLE
Add index page controller

### DIFF
--- a/src/main/java/com/example/nagoyameshi/controller/IndexController.java
+++ b/src/main/java/com/example/nagoyameshi/controller/IndexController.java
@@ -1,0 +1,13 @@
+package com.example.nagoyameshi.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class IndexController {
+
+    @GetMapping("/")
+    public String index() {
+        return "index";
+    }
+}

--- a/src/test/java/com/example/nagoyameshi/controller/IndexControllerTest.java
+++ b/src/test/java/com/example/nagoyameshi/controller/IndexControllerTest.java
@@ -1,0 +1,26 @@
+package com.example.nagoyameshi.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(IndexController.class)
+class IndexControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("GET / returns index view")
+    void testIndex() throws Exception {
+        mockMvc.perform(get("/"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("index"));
+    }
+}


### PR DESCRIPTION
## Summary
- create a new `IndexController` mapped to `/`
- test that `/` returns the `index` view

## Testing
- `mvnw test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684bc68b49ec83279e951efdcf4ee457