### PR TITLE
Fix circular dependency between SecurityConfig and UserServiceImpl

### DIFF
--- a/src/main/java/com/example/nagoyameshi/config/PasswordConfig.java
+++ b/src/main/java/com/example/nagoyameshi/config/PasswordConfig.java
@@ -1,0 +1,25 @@
+package com.example.nagoyameshi.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * パスワードのハッシュ化アルゴリズムを提供する設定クラスです。
+ * Spring Security 以外のサービスからも再利用できるよう、
+ * SecurityConfig とは分離して定義します。
+ */
+@Configuration
+public class PasswordConfig {
+    /**
+     * BCrypt を用いたパスワードエンコーダーの Bean を生成します。
+     * これを用いることで平文のパスワードを安全にハッシュ化できます。
+     *
+     * @return PasswordEncoder の実装クラス
+     */
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/example/nagoyameshi/config/SecurityConfig.java
+++ b/src/main/java/com/example/nagoyameshi/config/SecurityConfig.java
@@ -5,8 +5,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.example.nagoyameshi.service.UserServiceImpl;
 
@@ -16,7 +14,17 @@ import lombok.RequiredArgsConstructor;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+    /*
+     * PasswordEncoder は別クラス(PasswordConfig)で定義し、
+     * UserServiceImpl が依存する Bean を分離することで
+     * 循環依存を防止している。
+     */
 
+    /**
+     * 認証時にユーザー情報を取得するサービス実装です。
+     * UserServiceImpl は UserDetailsService を実装しているため、
+     * SecurityFilterChain の設定にそのまま利用できます。
+     */
     private final UserServiceImpl userService;
 
     @Bean
@@ -54,8 +62,4 @@ public class SecurityConfig {
             .build();
     }
 
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
 }


### PR DESCRIPTION
## Summary
- separate PasswordEncoder into new `PasswordConfig` to remove circular dependency
- update `SecurityConfig` with descriptive comments

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684bf2a32f5483278fedb74188db81f4