### PR TITLE
Add from address property for signup emails

### DIFF
--- a/src/main/java/com/example/nagoyameshi/event/SignupEventListener.java
+++ b/src/main/java/com/example/nagoyameshi/event/SignupEventListener.java
@@ -20,7 +20,7 @@ import lombok.RequiredArgsConstructor;
 public class SignupEventListener {
     private final JavaMailSender mailSender;
     private final UserService userService;
-    // application.properties で設定した送信元アドレスを注入
+    // application.properties の spring.mail.from プロパティを注入
     @Value("${spring.mail.from}")
     private String fromAddress;
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,3 +15,5 @@ spring.mail.password=55a3986eeae665
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 
+# SignupEventListener で利用する送信元アドレス
+spring.mail.from=noreply@example.com


### PR DESCRIPTION
## Summary
- document `spring.mail.from` property in `application.properties`
- clarify injection comment in `SignupEventListener`

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_684bf47a227083279d143975104e9e26