### PR TITLE
Replace MockBean with MockitoBean in tests

### DIFF
--- a/src/test/java/com/example/nagoyameshi/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/nagoyameshi/controller/AuthControllerTest.java
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+// Spring Framework が提供する MockitoBean を使用
+// MockBean は 3.4.0 以降非推奨となったため置き換える
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -19,7 +21,8 @@ class AuthControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    // UserService をモック化してテスト用のコンテキストに登録する
+    @MockitoBean
     private UserService userService;
 
     @Test

--- a/src/test/java/com/example/nagoyameshi/controller/RestaurantControllerTest.java
+++ b/src/test/java/com/example/nagoyameshi/controller/RestaurantControllerTest.java
@@ -11,7 +11,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+// 推奨される MockitoBean を利用してモックを作成
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -24,7 +25,8 @@ class RestaurantControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    // RestaurantService をモック化し、コンテキストに登録する
+    @MockitoBean
     private RestaurantService restaurantService;
 
     @WithMockUser(username = "testuser", roles = {"USER"})


### PR DESCRIPTION
## Summary
- switch deprecated `@MockBean` annotations to `@MockitoBean`
- add explanatory comments in test classes

## Testing
- `mvn -q test` *(fails: Bean definition errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ee5e147a88327a3c00df4372213eb