### PR TITLE
Implement email verification flow

### DIFF
--- a/src/main/java/com/example/nagoyameshi/controller/HomeController.java
+++ b/src/main/java/com/example/nagoyameshi/controller/HomeController.java
@@ -5,10 +5,16 @@ import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.ui.Model;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 import com.example.nagoyameshi.form.SignupForm;
 import com.example.nagoyameshi.service.UserService;
+import com.example.nagoyameshi.service.VerificationTokenService;
+import com.example.nagoyameshi.event.SignupEventPublisher;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,6 +24,10 @@ public class HomeController {
 
     /** ユーザー関連の処理を行うサービス */
     private final UserService userService;
+    /** 認証トークンを扱うサービス */
+    private final VerificationTokenService verificationTokenService;
+    /** サインアップ完了時のイベント発行クラス */
+    private final SignupEventPublisher signupEventPublisher;
 
     @GetMapping("/")
     public String index() {
@@ -53,7 +63,7 @@ public class HomeController {
      */
     @PostMapping("/signup")
     public String signup(@Validated SignupForm signupForm, BindingResult bindingResult,
-            RedirectAttributes redirectAttributes) {
+            RedirectAttributes redirectAttributes, HttpServletRequest request) {
 
         if (userService.isEmailRegistered(signupForm.getEmail())) {
             bindingResult.rejectValue("email", "email.registered", "既に登録済みのメールアドレスです。");
@@ -66,8 +76,35 @@ public class HomeController {
             return "auth/signup";
         }
 
-        userService.createUser(signupForm);
-        redirectAttributes.addFlashAttribute("successMessage", "会員登録が完了しました。");
+        // ユーザー登録（enabled=false で保存）
+        var user = userService.createUser(signupForm);
+
+        // リクエストURLからドメイン部分を取得しイベントへ渡す
+        String baseUrl = request.getRequestURL().toString().replace("/signup", "");
+        signupEventPublisher.publish(user, baseUrl);
+
+        redirectAttributes.addFlashAttribute("successMessage",
+                "ご入力いただいたメールアドレスに認証メールを送信しました。メールに記載されているリンクをクリックし、会員登録を完了してください。");
         return "redirect:/";
+    }
+
+    /**
+     * メール認証URLから呼び出される確認処理。
+     *
+     * @param token 認証トークン
+     * @param model ビューへ値を渡すモデル
+     * @return 認証結果表示画面
+     */
+    @GetMapping("/signup/verify")
+    public String verify(@RequestParam("token") String token, Model model) {
+        var vToken = verificationTokenService.findVerificationTokenByToken(token);
+        if (vToken.isPresent()) {
+            // トークンが見つかった場合はユーザーを有効化
+            userService.enableUser(vToken.get().getUser());
+            model.addAttribute("successMessage", "会員登録が完了しました。");
+        } else {
+            model.addAttribute("errorMessage", "トークンが無効です。");
+        }
+        return "auth/verify";
     }
 }

--- a/src/main/java/com/example/nagoyameshi/service/UserService.java
+++ b/src/main/java/com/example/nagoyameshi/service/UserService.java
@@ -21,7 +21,21 @@ public interface UserService {
      *
      * @param form 入力された会員情報
      */
-    void createUser(SignupForm form);
+    /**
+     * 会員登録フォームからユーザーを生成して保存する。
+     * 保存時点ではメール認証前のため enabled は false とする。
+     *
+     * @param form 入力された会員情報
+     * @return 保存したユーザーエンティティ
+     */
+    User createUser(SignupForm form);
+
+    /**
+     * 指定したユーザーを有効化する。
+     *
+     * @param user 有効化したいユーザー
+     */
+    void enableUser(User user);
 
     /**
      * メールアドレスがすでに登録済みか判定する。

--- a/src/main/java/com/example/nagoyameshi/service/UserServiceImpl.java
+++ b/src/main/java/com/example/nagoyameshi/service/UserServiceImpl.java
@@ -83,7 +83,7 @@ public class UserServiceImpl implements UserService {
      * {@inheritDoc}
      */
     @Override
-    public void createUser(SignupForm form) {
+    public User createUser(SignupForm form) {
         Role role = roleRepository.findByName("ROLE_FREE_MEMBER").orElseThrow();
 
         User user = User.builder()
@@ -101,11 +101,22 @@ public class UserServiceImpl implements UserService {
                 .email(form.getEmail())
                 .password(passwordEncoder.encode(form.getPassword()))
                 .role(role)
-                .enabled(true)
+                // メール認証前のため、アカウントを無効状態で作成
+                .enabled(false)
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
                 .build();
 
+        // ユーザーを保存して生成されたエンティティを返す
+        return userRepository.save(user);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void enableUser(User user) {
+        user.setEnabled(true);
         userRepository.save(user);
     }
 

--- a/src/test/java/com/example/nagoyameshi/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/nagoyameshi/controller/AuthControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.example.nagoyameshi.service.UserService;
 import com.example.nagoyameshi.event.SignupEventPublisher;
+import com.example.nagoyameshi.service.VerificationTokenService;
 
 @WebMvcTest(AuthController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -31,6 +32,10 @@ class AuthControllerTest {
     // SignupEventPublisher もモック化して登録する
     @MockitoBean
     private SignupEventPublisher signupEventPublisher;
+
+    // VerificationTokenService もモックとして登録
+    @MockitoBean
+    private VerificationTokenService verificationTokenService;
 
     @Test
     @DisplayName("POST /register はステータス200を返す")

--- a/src/test/java/com/example/nagoyameshi/controller/HomeControllerTest.java
+++ b/src/test/java/com/example/nagoyameshi/controller/HomeControllerTest.java
@@ -13,6 +13,8 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import com.example.nagoyameshi.service.UserService;
+import com.example.nagoyameshi.event.SignupEventPublisher;
+import com.example.nagoyameshi.service.VerificationTokenService;
 
 @WebMvcTest(HomeController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -21,6 +23,14 @@ class HomeControllerTest {
     // UserService をモック化してテスト用のコンテキストに登録する
     @MockitoBean
     private UserService userService;
+
+    // SignupEventPublisher をモック化
+    @MockitoBean
+    private SignupEventPublisher signupEventPublisher;
+
+    // VerificationTokenService もモック化
+    @MockitoBean
+    private VerificationTokenService verificationTokenService;
 
     @Autowired
     private MockMvc mockMvc;


### PR DESCRIPTION
## Summary
- save users with `enabled` set to false
- allow enabling users via new `enableUser` service method
- send verification email after signup and handle the verify endpoint
- update tests with new service dependencies

## Testing
- `mvn -DskipTests=false test`

------
https://chatgpt.com/codex/tasks/task_e_68501a166fd88327ae75708308d0cb74