### PR TITLE
Add admin category management

### DIFF
--- a/src/main/java/com/example/nagoyameshi/controller/admin/AdminCategoryController.java
+++ b/src/main/java/com/example/nagoyameshi/controller/admin/AdminCategoryController.java
@@ -1,0 +1,112 @@
+package com.example.nagoyameshi.controller.admin;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import com.example.nagoyameshi.entity.Category;
+import com.example.nagoyameshi.form.CategoryEditForm;
+import com.example.nagoyameshi.form.CategoryRegisterForm;
+import com.example.nagoyameshi.service.CategoryService;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 管理者用のカテゴリ管理コントローラ。
+ * 一覧表示・登録・更新・削除を提供する。
+ */
+@Controller
+@RequiredArgsConstructor
+public class AdminCategoryController {
+
+    /** カテゴリ情報を扱うサービス */
+    private final CategoryService categoryService;
+
+    /**
+     * カテゴリ一覧ページを表示する。
+     *
+     * @param pageable ページ情報
+     * @param keyword  検索キーワード
+     * @param model    ビューへ渡すモデル
+     * @return 一覧画面テンプレート名
+     */
+    @GetMapping("/admin/categories")
+    public String index(@PageableDefault(page = 0, size = 15, sort = "id", direction = Direction.ASC) Pageable pageable,
+                        @RequestParam(name = "keyword", required = false) String keyword,
+                        Model model) {
+        Page<Category> categoryPage;
+        if (keyword != null && !keyword.isBlank()) {
+            categoryPage = categoryService.findCategoriesByNameLike(keyword, pageable);
+        } else {
+            categoryPage = categoryService.findAllCategories(pageable);
+        }
+        model.addAttribute("categoryPage", categoryPage);
+        model.addAttribute("keyword", keyword);
+        model.addAttribute("categoryRegisterForm", new CategoryRegisterForm());
+        model.addAttribute("categoryEditForm", new CategoryEditForm());
+        return "admin/categories/index";
+    }
+
+    /**
+     * カテゴリを新規登録する。
+     */
+    @PostMapping("/admin/categories/create")
+    public String create(@Validated CategoryRegisterForm form, BindingResult bindingResult,
+                         RedirectAttributes redirectAttributes) {
+        if (bindingResult.hasErrors()) {
+            redirectAttributes.addFlashAttribute("errorMessage", "入力内容に誤りがあります。");
+            redirectAttributes.addFlashAttribute("categoryRegisterForm", form);
+            return "redirect:/admin/categories";
+        }
+        categoryService.createCategory(form);
+        redirectAttributes.addFlashAttribute("successMessage", "カテゴリを登録しました。");
+        return "redirect:/admin/categories";
+    }
+
+    /**
+     * 既存カテゴリを更新する。
+     */
+    @PostMapping("/admin/categories/{id}/update")
+    public String update(@PathVariable("id") Long id, @Validated CategoryEditForm form,
+                         BindingResult bindingResult, RedirectAttributes redirectAttributes) {
+        Optional<Category> categoryOpt = categoryService.findCategoryById(id);
+        if (categoryOpt.isEmpty()) {
+            redirectAttributes.addFlashAttribute("errorMessage", "カテゴリが存在しません。");
+            return "redirect:/admin/categories";
+        }
+        if (bindingResult.hasErrors()) {
+            redirectAttributes.addFlashAttribute("errorMessage", "入力内容に誤りがあります。");
+            return "redirect:/admin/categories";
+        }
+        categoryService.updateCategory(id, form);
+        redirectAttributes.addFlashAttribute("successMessage", "カテゴリを更新しました。");
+        return "redirect:/admin/categories";
+    }
+
+    /**
+     * カテゴリを削除する。
+     */
+    @PostMapping("/admin/categories/{id}/delete")
+    public String delete(@PathVariable("id") Long id, RedirectAttributes redirectAttributes) {
+        Optional<Category> categoryOpt = categoryService.findCategoryById(id);
+        if (categoryOpt.isEmpty()) {
+            redirectAttributes.addFlashAttribute("errorMessage", "カテゴリが存在しません。");
+            return "redirect:/admin/categories";
+        }
+        categoryService.deleteCategory(id);
+        redirectAttributes.addFlashAttribute("successMessage", "カテゴリを削除しました。");
+        return "redirect:/admin/categories";
+    }
+}

--- a/src/main/java/com/example/nagoyameshi/form/CategoryEditForm.java
+++ b/src/main/java/com/example/nagoyameshi/form/CategoryEditForm.java
@@ -1,0 +1,14 @@
+package com.example.nagoyameshi.form;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+/**
+ * カテゴリ編集時の入力内容を保持するフォーム。
+ */
+@Data
+public class CategoryEditForm {
+    /** カテゴリ名 */
+    @NotBlank(message = "カテゴリ名を入力してください。")
+    private String name;
+}

--- a/src/main/java/com/example/nagoyameshi/form/CategoryRegisterForm.java
+++ b/src/main/java/com/example/nagoyameshi/form/CategoryRegisterForm.java
@@ -1,0 +1,14 @@
+package com.example.nagoyameshi.form;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+/**
+ * カテゴリ登録時の入力内容を保持するフォーム。
+ */
+@Data
+public class CategoryRegisterForm {
+    /** カテゴリ名 */
+    @NotBlank(message = "カテゴリ名を入力してください。")
+    private String name;
+}

--- a/src/main/java/com/example/nagoyameshi/repository/CategoryRepository.java
+++ b/src/main/java/com/example/nagoyameshi/repository/CategoryRepository.java
@@ -1,8 +1,31 @@
 package com.example.nagoyameshi.repository;
 
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.example.nagoyameshi.entity.Category;
 
+/**
+ * カテゴリ情報へアクセスするリポジトリ。
+ */
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    /**
+     * 名前で部分一致検索を行い、ページング結果を返します。
+     *
+     * @param name     検索キーワード
+     * @param pageable ページ情報
+     * @return 取得したカテゴリページ
+     */
+    Page<Category> findByNameContaining(String name, Pageable pageable);
+
+    /**
+     * ID の降順で最初のレコードを取得します。
+     *
+     * @return もっとも新しいカテゴリ
+     */
+    Optional<Category> findFirstByOrderByIdDesc();
 }

--- a/src/main/java/com/example/nagoyameshi/service/CategoryService.java
+++ b/src/main/java/com/example/nagoyameshi/service/CategoryService.java
@@ -1,0 +1,46 @@
+package com.example.nagoyameshi.service;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.example.nagoyameshi.entity.Category;
+import com.example.nagoyameshi.form.CategoryEditForm;
+import com.example.nagoyameshi.form.CategoryRegisterForm;
+
+/**
+ * カテゴリ情報を操作するサービスインターフェース。
+ */
+public interface CategoryService {
+
+    /** 全カテゴリをページ取得する。 */
+    Page<Category> findAllCategories(Pageable pageable);
+
+    /**
+     * キーワードで部分一致検索する。
+     *
+     * @param keyword  検索ワード
+     * @param pageable ページ情報
+     * @return 検索結果ページ
+     */
+    Page<Category> findCategoriesByNameLike(String keyword, Pageable pageable);
+
+    /** ID を指定してカテゴリを取得する。 */
+    Optional<Category> findCategoryById(Long id);
+
+    /** 登録されているカテゴリ数を数える。 */
+    long countCategories();
+
+    /** 最後に登録されたカテゴリを取得する。 */
+    Optional<Category> findFirstCategoryByOrderByIdDesc();
+
+    /** カテゴリを登録する。 */
+    Category createCategory(CategoryRegisterForm form);
+
+    /** カテゴリを更新する。 */
+    Category updateCategory(Long id, CategoryEditForm form);
+
+    /** カテゴリを削除する。 */
+    void deleteCategory(Long id);
+}

--- a/src/main/java/com/example/nagoyameshi/service/CategoryServiceImpl.java
+++ b/src/main/java/com/example/nagoyameshi/service/CategoryServiceImpl.java
@@ -1,0 +1,80 @@
+package com.example.nagoyameshi.service;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import com.example.nagoyameshi.entity.Category;
+import com.example.nagoyameshi.form.CategoryEditForm;
+import com.example.nagoyameshi.form.CategoryRegisterForm;
+import com.example.nagoyameshi.repository.CategoryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * {@link CategoryService} の実装クラス。
+ * データベース操作は {@link CategoryRepository} を利用する。
+ */
+@Service
+@RequiredArgsConstructor
+public class CategoryServiceImpl implements CategoryService {
+
+    /** データベースアクセス用リポジトリ */
+    private final CategoryRepository categoryRepository;
+
+    /** {@inheritDoc} */
+    @Override
+    public Page<Category> findAllCategories(Pageable pageable) {
+        return categoryRepository.findAll(pageable);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Page<Category> findCategoriesByNameLike(String keyword, Pageable pageable) {
+        return categoryRepository.findByNameContaining(keyword, pageable);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Optional<Category> findCategoryById(Long id) {
+        return categoryRepository.findById(id);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public long countCategories() {
+        return categoryRepository.count();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Optional<Category> findFirstCategoryByOrderByIdDesc() {
+        return categoryRepository.findFirstByOrderByIdDesc();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Category createCategory(CategoryRegisterForm form) {
+        Category category = Category.builder()
+                .name(form.getName())
+                .build();
+        return categoryRepository.save(category);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Category updateCategory(Long id, CategoryEditForm form) {
+        Category category = categoryRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Category not found"));
+        category.setName(form.getName());
+        return categoryRepository.save(category);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void deleteCategory(Long id) {
+        categoryRepository.deleteById(id);
+    }
+}

--- a/src/main/resources/static/js/categories.js
+++ b/src/main/resources/static/js/categories.js
@@ -1,0 +1,25 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const editModal = document.getElementById('editCategoryModal');
+  if (editModal) {
+    editModal.addEventListener('show.bs.modal', event => {
+      const button = event.relatedTarget;
+      const id = button.getAttribute('data-id');
+      const name = button.getAttribute('data-name');
+      const form = editModal.querySelector('form');
+      form.action = `/admin/categories/${id}/update`;
+      form.querySelector('input[name="name"]').value = name;
+    });
+  }
+
+  const deleteModal = document.getElementById('deleteCategoryModal');
+  if (deleteModal) {
+    deleteModal.addEventListener('show.bs.modal', event => {
+      const button = event.relatedTarget;
+      const id = button.getAttribute('data-id');
+      const name = button.getAttribute('data-name');
+      const form = deleteModal.querySelector('form');
+      form.action = `/admin/categories/${id}/delete`;
+      deleteModal.querySelector('.modal-body span').textContent = name;
+    });
+  }
+});

--- a/src/main/resources/static/js/preview.js
+++ b/src/main/resources/static/js/preview.js
@@ -3,12 +3,12 @@ const imagePreview = document.getElementById('imagePreview');
 
 imageInput.addEventListener('change', () => {
   if (imageInput.files[0]) {
-    let fileReader = new FileReader();
+    const fileReader = new FileReader();
     fileReader.onload = () => {
       imagePreview.innerHTML = `<img src="${fileReader.result}" class="mb-3">`;
-    }
+    };
     fileReader.readAsDataURL(imageInput.files[0]);
   } else {
     imagePreview.innerHTML = '';
   }
-})
+});

--- a/src/main/resources/templates/admin/categories/index.html
+++ b/src/main/resources/templates/admin/categories/index.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html xmlns:th="https://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+    <head>
+        <div th:replace="~{fragment :: meta}"></div>
+        <div th:replace="~{fragment :: styles}"></div>
+        <title>カテゴリ一覧</title>
+    </head>
+    <body>
+        <div class="nagoyameshi-wrapper">
+            <div th:replace="~{fragment :: header}"></div>
+            <main>
+                <div class="container py-4 nagoyameshi-container">
+                    <div class="row justify-content-center">
+                        <div th:replace="~{fragment :: sidebar}"></div>
+                        <div class="col container">
+                            <div class="row justify-content-center">
+                                <div class="col-xxl-9 col-xl-10 col-lg-11">
+                                    <h1 class="mb-4 text-center">カテゴリ一覧</h1>
+                                    <div th:if="${successMessage}" class="alert alert-info">
+                                        <span th:text="${successMessage}"></span>
+                                    </div>
+                                    <div th:if="${errorMessage}" class="alert alert-danger">
+                                        <span th:text="${errorMessage}"></span>
+                                    </div>
+                                    <div class="d-flex justify-content-between align-items-end flex-wrap">
+                                        <form method="get" th:action="@{/admin/categories}" class="nagoyaemshi-admin-search-box mb-3">
+                                            <div class="input-group">
+                                                <input type="text" class="form-control" name="keyword" th:value="${keyword}" placeholder="カテゴリ名で検索">
+                                                <button type="submit" class="btn text-white shadow-sm nagoyameshi-btn">検索</button>
+                                            </div>
+                                        </form>
+                                        <button type="button" class="btn text-white shadow-sm mb-3 nagoyameshi-btn" data-bs-toggle="modal" data-bs-target="#createCategoryModal">＋ 新規登録</button>
+                                    </div>
+                                    <div>
+                                        <p class="mb-0" th:text="${'計' + #numbers.formatInteger(categoryPage.getTotalElements(), 1, 'COMMA') + '件'}"></p>
+                                    </div>
+                                    <table class="table table-hover">
+                                        <thead>
+                                            <tr>
+                                                <th scope="col">ID</th>
+                                                <th scope="col">カテゴリ名</th>
+                                                <th scope="col"></th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <tr th:each="category : ${categoryPage}">
+                                                <td th:text="${category.id}"></td>
+                                                <td th:text="${category.name}"></td>
+                                                <td>
+                                                    <a href="#" class="me-2" data-bs-toggle="modal" data-bs-target="#editCategoryModal" th:data-id="${category.id}" th:data-name="${category.name}">編集</a>
+                                                    <a href="#" class="link-secondary" data-bs-toggle="modal" data-bs-target="#deleteCategoryModal" th:data-id="${category.id}" th:data-name="${category.name}">削除</a>
+                                                </td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                    <div th:if="${categoryPage.totalPages > 1}" class="d-flex justify-content-center">
+                                        <nav aria-label="カテゴリ一覧ページ">
+                                            <ul class="pagination">
+                                                <li class="page-item">
+                                                    <span th:if="${categoryPage.first}" class="page-link disabled">‹</span>
+                                                    <a th:unless="${categoryPage.first}" th:href="@{/admin/categories(page=${categoryPage.number - 1}, keyword=${keyword})}" class="page-link">‹</a>
+                                                </li>
+                                                <li th:each="i : ${#numbers.sequence(0, categoryPage.totalPages - 1)}" class="page-item">
+                                                    <span th:if="${i == categoryPage.number}" class="page-link active" th:text="${i + 1}"></span>
+                                                    <a th:unless="${i == categoryPage.number}" th:href="@{/admin/categories(page=${i}, keyword=${keyword})}" class="page-link" th:text="${i + 1}"></a>
+                                                </li>
+                                                <li class="page-item">
+                                                    <span th:if="${categoryPage.last}" class="page-link disabled">›</span>
+                                                    <a th:unless="${categoryPage.last}" th:href="@{/admin/categories(page=${categoryPage.number + 1}, keyword=${keyword})}" class="page-link">›</a>
+                                                </li>
+                                            </ul>
+                                        </nav>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </main>
+            <div th:replace="~{fragment :: footer}"></div>
+        </div>
+        <div th:replace="~{fragment :: scripts}"></div>
+        <script th:src="@{/js/categories.js}"></script>
+        <!-- 登録用モーダル -->
+        <div class="modal fade" id="createCategoryModal" tabindex="-1" aria-labelledby="createCategoryModalLabel">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="createCategoryModalLabel">カテゴリ登録</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
+                    </div>
+                    <div class="modal-body">
+                        <form method="post" th:action="@{/admin/categories/create}" th:object="${categoryRegisterForm}">
+                            <div class="form-group mb-3">
+                                <label for="name" class="col-form-label fw-bold">カテゴリ名</label>
+                                <div th:if="${#fields.hasErrors('name')}" class="text-danger small mb-2" th:errors="*{name}"></div>
+                                <input type="text" class="form-control" th:field="*{name}" autofocus>
+                            </div>
+                            <div class="form-group d-flex justify-content-center">
+                                <button type="submit" class="btn text-white shadow-sm nagoyameshi-btn">登録</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <!-- 編集用モーダル -->
+        <div class="modal fade" id="editCategoryModal" tabindex="-1" aria-labelledby="editCategoryModalLabel">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="editCategoryModalLabel">カテゴリ編集</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
+                    </div>
+                    <div class="modal-body">
+                        <form method="post" th:action="@{/admin/categories/0/update}" th:object="${categoryEditForm}">
+                            <div class="form-group mb-3">
+                                <label for="editName" class="col-form-label fw-bold">カテゴリ名</label>
+                                <div th:if="${#fields.hasErrors('name')}" class="text-danger small mb-2" th:errors="*{name}"></div>
+                                <input type="text" id="editName" class="form-control" th:field="*{name}" autofocus>
+                            </div>
+                            <div class="form-group d-flex justify-content-center">
+                                <button type="submit" class="btn text-white shadow-sm nagoyameshi-btn">更新</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <!-- 削除用モーダル -->
+        <div class="modal fade" id="deleteCategoryModal" tabindex="-1" aria-labelledby="deleteCategoryModalLabel">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="deleteCategoryModalLabel">削除確認</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p><span></span> を削除してもよろしいですか？</p>
+                    </div>
+                    <div class="modal-footer">
+                        <form method="post" th:action="@{/admin/categories/0/delete}">
+                            <button type="submit" class="btn text-white shadow-sm nagoyameshi-btn-danger">削除</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>

--- a/src/test/java/com/example/nagoyameshi/controller/admin/AdminCategoryControllerTest.java
+++ b/src/test/java/com/example/nagoyameshi/controller/admin/AdminCategoryControllerTest.java
@@ -1,0 +1,171 @@
+package com.example.nagoyameshi.controller.admin;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.example.nagoyameshi.entity.Category;
+import com.example.nagoyameshi.form.CategoryEditForm;
+import com.example.nagoyameshi.form.CategoryRegisterForm;
+import com.example.nagoyameshi.security.UserDetailsServiceImpl;
+import com.example.nagoyameshi.security.WebSecurityConfig;
+import com.example.nagoyameshi.service.CategoryService;
+
+/**
+ * {@link AdminCategoryController} の動作を検証するテストクラス。
+ */
+@WebMvcTest(AdminCategoryController.class)
+@Import(WebSecurityConfig.class)
+@AutoConfigureMockMvc
+class AdminCategoryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CategoryService categoryService;
+
+    @MockitoBean
+    private UserDetailsServiceImpl userDetailsService;
+
+    // --- 一覧ページのテスト ------------------------------------------------------
+
+    @Test
+    @DisplayName("未ログインの場合は一覧ページからログインページにリダイレクトされる")
+    void 未ログインの一覧ページアクセスはログインにリダイレクト() throws Exception {
+        mockMvc.perform(get("/admin/categories"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("**/login"));
+    }
+
+    @Test
+    @DisplayName("一般ユーザーは一覧ページにアクセスすると403エラー")
+    void 一般ユーザーは一覧ページにアクセスできない() throws Exception {
+        when(categoryService.findAllCategories(any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 10), 0));
+
+        mockMvc.perform(get("/admin/categories").with(user("user").roles("FREE_MEMBER")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("管理者は一覧ページを閲覧できる")
+    void 管理者は一覧ページを閲覧できる() throws Exception {
+        when(categoryService.findCategoriesByNameLike(any(), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 10), 0));
+
+        mockMvc.perform(get("/admin/categories").param("keyword", "ラーメン").param("page", "0")
+                .with(user("admin").roles("ADMIN")))
+                .andExpect(status().isOk())
+                .andExpect(view().name("admin/categories/index"));
+    }
+
+    // --- カテゴリ登録のテスト ----------------------------------------------------
+
+    @Test
+    @DisplayName("未ログインの場合はカテゴリを登録せずにログインページにリダイレクトする")
+    void 未ログインのカテゴリ登録はログインにリダイレクト() throws Exception {
+        mockMvc.perform(post("/admin/categories/create"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("**/login"));
+    }
+
+    @Test
+    @DisplayName("一般ユーザーはカテゴリを登録できず403エラー")
+    void 一般ユーザーはカテゴリを登録できない() throws Exception {
+        mockMvc.perform(post("/admin/categories/create").with(user("user").roles("FREE_MEMBER")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("管理者はカテゴリ登録後に一覧ページへリダイレクトされる")
+    void 管理者はカテゴリ登録後に一覧ページへリダイレクトされる() throws Exception {
+        when(categoryService.createCategory(any(CategoryRegisterForm.class)))
+                .thenReturn(Category.builder().id(1L).name("name").build());
+
+        mockMvc.perform(post("/admin/categories/create")
+                        .with(user("admin").roles("ADMIN"))
+                        .param("name", "name"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/admin/categories"));
+    }
+
+    // --- カテゴリ更新のテスト ----------------------------------------------------
+
+    @Test
+    @DisplayName("未ログインの場合はカテゴリを更新せずにログインページにリダイレクトする")
+    void 未ログインのカテゴリ更新はログインにリダイレクト() throws Exception {
+        mockMvc.perform(post("/admin/categories/1/update"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("**/login"));
+    }
+
+    @Test
+    @DisplayName("一般ユーザーはカテゴリを更新できず403エラー")
+    void 一般ユーザーはカテゴリを更新できない() throws Exception {
+        mockMvc.perform(post("/admin/categories/1/update").with(user("user").roles("FREE_MEMBER")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("管理者はカテゴリ更新後に一覧ページへリダイレクトされる")
+    void 管理者はカテゴリ更新後に一覧ページへリダイレクトされる() throws Exception {
+        when(categoryService.findCategoryById(1L)).thenReturn(Optional.of(Category.builder().id(1L).build()));
+        when(categoryService.updateCategory(any(Long.class), any(CategoryEditForm.class)))
+                .thenReturn(Category.builder().id(1L).build());
+
+        mockMvc.perform(post("/admin/categories/1/update")
+                        .with(user("admin").roles("ADMIN"))
+                        .param("name", "name"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/admin/categories"));
+    }
+
+    // --- カテゴリ削除のテスト ----------------------------------------------------
+
+    @Test
+    @DisplayName("未ログインの場合はカテゴリを削除せずにログインページにリダイレクトする")
+    void 未ログインのカテゴリ削除はログインにリダイレクト() throws Exception {
+        mockMvc.perform(post("/admin/categories/1/delete"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("**/login"));
+    }
+
+    @Test
+    @DisplayName("一般ユーザーはカテゴリを削除できず403エラー")
+    void 一般ユーザーはカテゴリを削除できない() throws Exception {
+        mockMvc.perform(post("/admin/categories/1/delete").with(user("user").roles("FREE_MEMBER")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("管理者はカテゴリ削除後に一覧ページへリダイレクトされる")
+    void 管理者はカテゴリ削除後に一覧ページへリダイレクトされる() throws Exception {
+        when(categoryService.findCategoryById(1L)).thenReturn(Optional.of(Category.builder().id(1L).build()));
+
+        mockMvc.perform(post("/admin/categories/1/delete").with(user("admin").roles("ADMIN")))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/admin/categories"));
+    }
+}


### PR DESCRIPTION
## Summary
- implement category repository with search helpers
- add forms and services for categories
- implement admin controller and view for categories
- add JS for editing and deleting categories via modals
- provide controller tests for admin category management
- fix preview image script

## Testing
- `mvn test -DskipTests=false`

------
https://chatgpt.com/codex/tasks/task_e_68561e701170832782974c444e6e78ea