### PR TITLE
Implement user profile editing feature

### DIFF
--- a/src/main/java/com/example/nagoyameshi/controller/UserController.java
+++ b/src/main/java/com/example/nagoyameshi/controller/UserController.java
@@ -1,0 +1,100 @@
+package com.example.nagoyameshi.controller;
+
+import java.time.format.DateTimeFormatter;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import com.example.nagoyameshi.entity.User;
+import com.example.nagoyameshi.form.UserEditForm;
+import com.example.nagoyameshi.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 会員向けの情報表示・編集機能を提供するコントローラ。
+ */
+@Controller
+@RequiredArgsConstructor
+public class UserController {
+
+    /** ユーザー関連の処理を行うサービス */
+    private final UserService userService;
+
+    /**
+     * 会員情報ページを表示する。
+     *
+     * @param model 画面へ渡すモデル
+     * @return 会員情報画面のテンプレート名
+     */
+    @GetMapping("/user")
+    public String index(Model model) {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        User user = userService.findUserByEmail(email);
+        model.addAttribute("user", user);
+        return "user/index";
+    }
+
+    /**
+     * 会員情報編集ページを表示する。
+     *
+     * @param model 画面へ渡すモデル
+     * @return 会員情報編集画面のテンプレート名
+     */
+    @GetMapping("/user/edit")
+    public String edit(Model model) {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        User user = userService.findUserByEmail(email);
+        // 誕生日はフォーム用に文字列へ変換（nullはそのまま）
+        String birthday = user.getBirthday() == null ? null
+                : user.getBirthday().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        UserEditForm form = new UserEditForm(
+                user.getName(),
+                user.getFurigana(),
+                user.getPostalCode(),
+                user.getAddress(),
+                user.getPhoneNumber(),
+                birthday,
+                user.getOccupation(),
+                user.getEmail());
+        model.addAttribute("userEditForm", form);
+        return "user/edit";
+    }
+
+    /**
+     * 会員情報を更新する。
+     *
+     * @param userEditForm      入力フォーム
+     * @param bindingResult     バリデーション結果
+     * @param redirectAttributes リダイレクト時に渡す属性
+     * @param model             画面へ渡すモデル
+     * @return エラー時は編集画面、成功時は会員情報画面へリダイレクト
+     */
+    @PostMapping("/user/update")
+    public String update(@Validated UserEditForm userEditForm, BindingResult bindingResult,
+                         RedirectAttributes redirectAttributes, Model model) {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        User currentUser = userService.findUserByEmail(email);
+
+        // メールアドレスが変更されている場合は重複チェックを行う
+        if (userService.isEmailChanged(userEditForm, currentUser)
+                && userService.isEmailRegistered(userEditForm.getEmail())) {
+            bindingResult.rejectValue("email", "email.registered", "既に登録済みのメールアドレスです。");
+        }
+
+        if (bindingResult.hasErrors()) {
+            model.addAttribute("userEditForm", userEditForm);
+            return "user/edit";
+        }
+
+        userService.updateUser(userEditForm, currentUser);
+        redirectAttributes.addFlashAttribute("successMessage", "会員情報を編集しました。");
+        return "redirect:/user";
+    }
+}

--- a/src/main/java/com/example/nagoyameshi/form/UserEditForm.java
+++ b/src/main/java/com/example/nagoyameshi/form/UserEditForm.java
@@ -1,0 +1,51 @@
+package com.example.nagoyameshi.form;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 会員情報編集フォームの入力内容を保持するクラス。
+ * 入力値検証用のアノテーションを付けてバリデーションを行う。
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserEditForm {
+    /** 氏名 */
+    @NotBlank(message = "氏名を入力してください。")
+    private String name;
+
+    /** フリガナ */
+    @NotBlank(message = "フリガナを入力してください。")
+    private String furigana;
+
+    /** 郵便番号(7桁数字) */
+    @NotBlank(message = "郵便番号を入力してください。")
+    @Pattern(regexp = "^[0-9]{7}$", message = "郵便番号は7桁の半角数字で入力してください。")
+    private String postalCode;
+
+    /** 住所 */
+    @NotBlank(message = "住所を入力してください。")
+    private String address;
+
+    /** 電話番号(10～11桁数字) */
+    @NotBlank(message = "電話番号を入力してください。")
+    @Pattern(regexp = "^[0-9]{10,11}$", message = "電話番号は10桁または11桁の半角数字で入力してください。")
+    private String phoneNumber;
+
+    /** 誕生日 (任意: 空文字または8桁数字) */
+    @Pattern(regexp = "^$|^[0-9]{8}$", message = "誕生日は8桁の半角数字で入力してください。")
+    private String birthday;
+
+    /** 職業 (任意) */
+    private String occupation;
+
+    /** メールアドレス */
+    @NotBlank(message = "メールアドレスを入力してください。")
+    @Email(message = "メールアドレスは正しい形式で入力してください。")
+    private String email;
+}

--- a/src/main/java/com/example/nagoyameshi/service/UserService.java
+++ b/src/main/java/com/example/nagoyameshi/service/UserService.java
@@ -3,6 +3,7 @@ package com.example.nagoyameshi.service;
 import com.example.nagoyameshi.dto.RegisterRequest;
 import com.example.nagoyameshi.entity.User;
 import com.example.nagoyameshi.form.SignupForm;
+import com.example.nagoyameshi.form.UserEditForm;
 
 public interface UserService {
     User register(RegisterRequest request);
@@ -52,4 +53,30 @@ public interface UserService {
      * @return 一致していれば true
      */
     boolean isSamePassword(String password, String passwordConfirmation);
+
+    /**
+     * 入力フォームの内容でユーザー情報を更新する。
+     *
+     * @param form  入力された会員情報
+     * @param user  更新対象のユーザー
+     * @return 更新後のユーザーエンティティ
+     */
+    User updateUser(UserEditForm form, User user);
+
+    /**
+     * フォームに入力されたメールアドレスが現在のユーザーと異なるか確認する。
+     *
+     * @param form        入力フォーム
+     * @param currentUser 現在のユーザー
+     * @return 変更されていれば true
+     */
+    boolean isEmailChanged(UserEditForm form, User currentUser);
+
+    /**
+     * メールアドレスからユーザーを検索する。
+     *
+     * @param email メールアドレス
+     * @return 該当ユーザー（存在しない場合は null）
+     */
+    User findUserByEmail(String email);
 }

--- a/src/main/java/com/example/nagoyameshi/service/UserServiceImpl.java
+++ b/src/main/java/com/example/nagoyameshi/service/UserServiceImpl.java
@@ -12,6 +12,7 @@ import com.example.nagoyameshi.entity.Role;
 import com.example.nagoyameshi.entity.User;
 import com.example.nagoyameshi.entity.VerificationToken;
 import com.example.nagoyameshi.form.SignupForm;
+import com.example.nagoyameshi.form.UserEditForm;
 import com.example.nagoyameshi.repository.RoleRepository;
 import com.example.nagoyameshi.repository.UserRepository;
 import com.example.nagoyameshi.repository.VerificationTokenRepository;
@@ -114,5 +115,40 @@ public class UserServiceImpl implements UserService {
             return passwordConfirmation == null;
         }
         return password.equals(passwordConfirmation);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public User updateUser(UserEditForm form, User user) {
+        user.setName(form.getName());
+        user.setFurigana(form.getFurigana());
+        user.setPostalCode(form.getPostalCode());
+        user.setAddress(form.getAddress());
+        user.setPhoneNumber(form.getPhoneNumber());
+        // 空文字の場合は null を設定する
+        if (form.getBirthday() == null || form.getBirthday().isEmpty()) {
+            user.setBirthday(null);
+        } else {
+            user.setBirthday(LocalDate.parse(form.getBirthday()));
+        }
+        if (form.getOccupation() == null || form.getOccupation().isEmpty()) {
+            user.setOccupation(null);
+        } else {
+            user.setOccupation(form.getOccupation());
+        }
+        user.setEmail(form.getEmail());
+        return userRepository.save(user);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean isEmailChanged(UserEditForm form, User currentUser) {
+        return !currentUser.getEmail().equals(form.getEmail());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public User findUserByEmail(String email) {
+        return userRepository.findByEmail(email).orElse(null);
     }
 }

--- a/src/test/java/com/example/nagoyameshi/controller/UserControllerTest.java
+++ b/src/test/java/com/example/nagoyameshi/controller/UserControllerTest.java
@@ -1,0 +1,139 @@
+package com.example.nagoyameshi.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.example.nagoyameshi.entity.Role;
+import com.example.nagoyameshi.entity.User;
+import com.example.nagoyameshi.form.UserEditForm;
+import com.example.nagoyameshi.security.UserDetailsServiceImpl;
+import com.example.nagoyameshi.security.WebSecurityConfig;
+import com.example.nagoyameshi.service.UserService;
+import com.example.nagoyameshi.security.UserDetailsImpl;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import java.util.List;
+
+/**
+ * {@link UserController} の動作を検証するテストクラス。
+ */
+@WebMvcTest(UserController.class)
+@Import(WebSecurityConfig.class)
+@AutoConfigureMockMvc
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UserService userService;
+
+    @MockitoBean
+    private UserDetailsServiceImpl userDetailsService;
+
+    // --- 表示ページのテスト ----------------------------------------------------
+
+    @Test
+    @DisplayName("未ログインの場合は会員情報ページからログインページにリダイレクトされる")
+    void 未ログインの会員情報アクセスはログインにリダイレクト() throws Exception {
+        mockMvc.perform(get("/user"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("**/login"));
+    }
+
+    @Test
+    @DisplayName("未ログインの場合は会員情報編集ページからログインページにリダイレクトされる")
+    void 未ログインの編集ページアクセスはログインにリダイレクト() throws Exception {
+        mockMvc.perform(get("/user/edit"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("**/login"));
+    }
+
+    @Test
+    @DisplayName("ログイン済みの場合は会員情報ページを閲覧できる")
+    void ログイン済みの場合は会員情報ページを閲覧できる() throws Exception {
+        User user = User.builder()
+                .id(1L)
+                .name("侍 太郎")
+                .email("taro.samurai@example.com")
+                .role(Role.builder().name("ROLE_FREE_MEMBER").build())
+                .build();
+        when(userService.findUserByEmail("taro.samurai@example.com")).thenReturn(user);
+        UserDetailsImpl principal = new UserDetailsImpl(user,
+                List.of(new SimpleGrantedAuthority("ROLE_FREE_MEMBER")));
+
+        mockMvc.perform(get("/user").with(user(principal)))
+                .andExpect(status().isOk())
+                .andExpect(view().name("user/index"));
+    }
+
+    @Test
+    @DisplayName("ログイン済みの場合は会員情報編集ページを閲覧できる")
+    void ログイン済みの場合は会員情報編集ページを閲覧できる() throws Exception {
+        User user = User.builder()
+                .id(1L)
+                .name("侍 太郎")
+                .furigana("サムライ タロウ")
+                .postalCode("1010022")
+                .address("東京都千代田区")
+                .phoneNumber("09012345678")
+                .birthday(java.time.LocalDate.of(1990, 1, 1))
+                .occupation("エンジニア")
+                .email("taro.samurai@example.com")
+                .role(Role.builder().name("ROLE_FREE_MEMBER").build())
+                .build();
+        when(userService.findUserByEmail("taro.samurai@example.com")).thenReturn(user);
+        UserDetailsImpl principal = new UserDetailsImpl(user,
+                List.of(new SimpleGrantedAuthority("ROLE_FREE_MEMBER")));
+
+        mockMvc.perform(get("/user/edit").with(user(principal)))
+                .andExpect(status().isOk())
+                .andExpect(view().name("user/edit"));
+    }
+
+    // --- 更新処理のテスト ------------------------------------------------------
+
+    @Test
+    @DisplayName("ログイン済みの場合は会員情報を更新できる")
+    void ログイン済みの場合は会員情報を更新できる() throws Exception {
+        User currentUser = User.builder()
+                .id(1L)
+                .name("侍 太郎")
+                .email("taro.samurai@example.com")
+                .role(Role.builder().name("ROLE_FREE_MEMBER").build())
+                .build();
+        when(userService.findUserByEmail("taro.samurai@example.com")).thenReturn(currentUser);
+        when(userService.isEmailChanged(any(UserEditForm.class), any(User.class))).thenReturn(false);
+        when(userService.updateUser(any(UserEditForm.class), any(User.class))).thenReturn(currentUser);
+        UserDetailsImpl principal = new UserDetailsImpl(currentUser,
+                List.of(new SimpleGrantedAuthority("ROLE_FREE_MEMBER")));
+
+        mockMvc.perform(post("/user/update")
+                .with(user(principal))
+                .param("name", "侍 太郎")
+                .param("furigana", "サムライ タロウ")
+                .param("postalCode", "1010022")
+                .param("address", "東京都千代田区")
+                .param("phoneNumber", "09012345678")
+                .param("birthday", "19900101")
+                .param("occupation", "エンジニア")
+                .param("email", "taro.samurai@example.com"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/user"));
+    }
+}


### PR DESCRIPTION
## Summary
- add `UserEditForm` with validation rules
- allow viewing and editing personal info via new `UserController`
- extend `UserService` with profile update helpers
- implement service methods in `UserServiceImpl`
- add controller tests for user pages

## Testing
- `./mvnw test`

------
https://chatgpt.com/codex/tasks/task_e_6857bb9abc8c83279c8d351f69ac55bf