### PR TITLE
Fix CSRF issue in reviews page

### DIFF
--- a/src/main/java/com/example/nagoyameshi/security/WebSecurityConfig.java
+++ b/src/main/java/com/example/nagoyameshi/security/WebSecurityConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.config.Customizer;
 
 import lombok.RequiredArgsConstructor;
 
@@ -32,8 +33,8 @@ public class WebSecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
-                // CSRF 保護は今回は無効化
-                .csrf(csrf -> csrf.disable())
+                // CSRF 保護を有効化して、すべてのPOSTリクエストを安全に処理
+                .csrf(Customizer.withDefaults())
                 // URL ごとのアクセス許可設定
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(

--- a/src/main/resources/templates/reviews/index.html
+++ b/src/main/resources/templates/reviews/index.html
@@ -21,8 +21,9 @@
                                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
                             </div>
                             <div class="modal-footer">
-                                <form method="post"action="" name="deleteReviewForm">
-                                    <input type="hidden" name="_csrf" th:value="${_csrf.token}"/>
+                                <form method="post" action="" name="deleteReviewForm">
+                                    <!-- CSRFトークンを含めることで、悪意あるリクエストから保護する -->
+                                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                                     <button type="submit" class="btn text-white shadow-sm nagoyameshi-btn-danger">削除</button>
                                 </form>
                             </div>

--- a/src/test/java/com/example/nagoyameshi/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/nagoyameshi/controller/AuthControllerTest.java
@@ -1,6 +1,7 @@
 package com.example.nagoyameshi.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.DisplayName;
@@ -37,7 +38,7 @@ class AuthControllerTest {
     @DisplayName("POST /register はステータス200を返す")
     void registerメソッドはステータス200を返す() throws Exception {
         String json = "{\"email\":\"a@example.com\",\"password\":\"pass\"}";
-        mockMvc.perform(post("/register").contentType(MediaType.APPLICATION_JSON).content(json))
+        mockMvc.perform(post("/register").with(csrf()).contentType(MediaType.APPLICATION_JSON).content(json))
                 .andExpect(status().isOk());
     }
 }

--- a/src/test/java/com/example/nagoyameshi/controller/UserControllerTest.java
+++ b/src/test/java/com/example/nagoyameshi/controller/UserControllerTest.java
@@ -3,6 +3,7 @@ package com.example.nagoyameshi.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
@@ -123,7 +124,7 @@ class UserControllerTest {
         UserDetailsImpl principal = new UserDetailsImpl(currentUser,
                 List.of(new SimpleGrantedAuthority("ROLE_FREE_MEMBER")));
 
-        mockMvc.perform(post("/user/update")
+        mockMvc.perform(post("/user/update").with(csrf())
                 .with(user(principal))
                 .param("name", "侍 太郎")
                 .param("furigana", "サムライ タロウ")

--- a/src/test/java/com/example/nagoyameshi/controller/admin/AdminCategoryControllerTest.java
+++ b/src/test/java/com/example/nagoyameshi/controller/admin/AdminCategoryControllerTest.java
@@ -3,6 +3,7 @@ package com.example.nagoyameshi.controller.admin;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
@@ -86,7 +87,7 @@ class AdminCategoryControllerTest {
     @Test
     @DisplayName("未ログインの場合はカテゴリを登録せずにログインページにリダイレクトする")
     void 未ログインのカテゴリ登録はログインにリダイレクト() throws Exception {
-        mockMvc.perform(post("/admin/categories/create"))
+        mockMvc.perform(post("/admin/categories/create").with(csrf()))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrlPattern("**/login"));
     }
@@ -94,7 +95,7 @@ class AdminCategoryControllerTest {
     @Test
     @DisplayName("一般ユーザーはカテゴリを登録できず403エラー")
     void 一般ユーザーはカテゴリを登録できない() throws Exception {
-        mockMvc.perform(post("/admin/categories/create").with(user("user").roles("FREE_MEMBER")))
+        mockMvc.perform(post("/admin/categories/create").with(user("user").roles("FREE_MEMBER")).with(csrf()))
                 .andExpect(status().isForbidden());
     }
 
@@ -105,6 +106,7 @@ class AdminCategoryControllerTest {
                 .thenReturn(Category.builder().id(1L).name("name").build());
 
         mockMvc.perform(post("/admin/categories/create")
+                        .with(csrf())
                         .with(user("admin").roles("ADMIN"))
                         .param("name", "name"))
                 .andExpect(status().is3xxRedirection())
@@ -116,7 +118,7 @@ class AdminCategoryControllerTest {
     @Test
     @DisplayName("未ログインの場合はカテゴリを更新せずにログインページにリダイレクトする")
     void 未ログインのカテゴリ更新はログインにリダイレクト() throws Exception {
-        mockMvc.perform(post("/admin/categories/1/update"))
+        mockMvc.perform(post("/admin/categories/1/update").with(csrf()))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrlPattern("**/login"));
     }
@@ -124,7 +126,7 @@ class AdminCategoryControllerTest {
     @Test
     @DisplayName("一般ユーザーはカテゴリを更新できず403エラー")
     void 一般ユーザーはカテゴリを更新できない() throws Exception {
-        mockMvc.perform(post("/admin/categories/1/update").with(user("user").roles("FREE_MEMBER")))
+        mockMvc.perform(post("/admin/categories/1/update").with(user("user").roles("FREE_MEMBER")).with(csrf()))
                 .andExpect(status().isForbidden());
     }
 
@@ -136,6 +138,7 @@ class AdminCategoryControllerTest {
                 .thenReturn(Category.builder().id(1L).build());
 
         mockMvc.perform(post("/admin/categories/1/update")
+                        .with(csrf())
                         .with(user("admin").roles("ADMIN"))
                         .param("name", "name"))
                 .andExpect(status().is3xxRedirection())
@@ -147,7 +150,7 @@ class AdminCategoryControllerTest {
     @Test
     @DisplayName("未ログインの場合はカテゴリを削除せずにログインページにリダイレクトする")
     void 未ログインのカテゴリ削除はログインにリダイレクト() throws Exception {
-        mockMvc.perform(post("/admin/categories/1/delete"))
+        mockMvc.perform(post("/admin/categories/1/delete").with(csrf()))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrlPattern("**/login"));
     }
@@ -155,7 +158,7 @@ class AdminCategoryControllerTest {
     @Test
     @DisplayName("一般ユーザーはカテゴリを削除できず403エラー")
     void 一般ユーザーはカテゴリを削除できない() throws Exception {
-        mockMvc.perform(post("/admin/categories/1/delete").with(user("user").roles("FREE_MEMBER")))
+        mockMvc.perform(post("/admin/categories/1/delete").with(user("user").roles("FREE_MEMBER")).with(csrf()))
                 .andExpect(status().isForbidden());
     }
 
@@ -164,7 +167,7 @@ class AdminCategoryControllerTest {
     void 管理者はカテゴリ削除後に一覧ページへリダイレクトされる() throws Exception {
         when(categoryService.findCategoryById(1L)).thenReturn(Optional.of(Category.builder().id(1L).build()));
 
-        mockMvc.perform(post("/admin/categories/1/delete").with(user("admin").roles("ADMIN")))
+        mockMvc.perform(post("/admin/categories/1/delete").with(user("admin").roles("ADMIN")).with(csrf()))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/admin/categories"));
     }

--- a/src/test/java/com/example/nagoyameshi/controller/admin/AdminCompanyControllerTest.java
+++ b/src/test/java/com/example/nagoyameshi/controller/admin/AdminCompanyControllerTest.java
@@ -3,6 +3,7 @@ package com.example.nagoyameshi.controller.admin;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
@@ -111,7 +112,7 @@ class AdminCompanyControllerTest {
     @Test
     @DisplayName("未ログインの場合は会社概要を更新できずログインページにリダイレクトされる")
     void 未ログインの更新はログインにリダイレクト() throws Exception {
-        mockMvc.perform(post("/admin/company/update"))
+        mockMvc.perform(post("/admin/company/update").with(csrf()))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrlPattern("**/login"));
     }
@@ -119,7 +120,7 @@ class AdminCompanyControllerTest {
     @Test
     @DisplayName("一般ユーザーは会社概要を更新できず403エラー")
     void 一般ユーザーは会社概要を更新できない() throws Exception {
-        mockMvc.perform(post("/admin/company/update").with(user("user").roles("FREE_MEMBER")))
+        mockMvc.perform(post("/admin/company/update").with(user("user").roles("FREE_MEMBER")).with(csrf()))
                 .andExpect(status().isForbidden());
     }
 
@@ -130,6 +131,7 @@ class AdminCompanyControllerTest {
                 .thenReturn(Company.builder().id(1L).build());
 
         mockMvc.perform(post("/admin/company/update")
+                        .with(csrf())
                         .with(user("admin").roles("ADMIN"))
                         .param("name", "company")
                         .param("postalCode", "1234567")

--- a/src/test/java/com/example/nagoyameshi/controller/admin/AdminRestaurantControllerTest.java
+++ b/src/test/java/com/example/nagoyameshi/controller/admin/AdminRestaurantControllerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -178,7 +179,7 @@ class AdminRestaurantControllerTest {
     @Test
     @DisplayName("未ログインの場合は店舗を登録せずにログインページにリダイレクトする")
     void 未ログインの店舗登録はログインにリダイレクト() throws Exception {
-        mockMvc.perform(post("/admin/restaurants/create"))
+        mockMvc.perform(post("/admin/restaurants/create").with(csrf()))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrlPattern("**/login"));
     }
@@ -186,7 +187,7 @@ class AdminRestaurantControllerTest {
     @Test
     @DisplayName("一般ユーザーは店舗を登録できず403エラー")
     void 一般ユーザーは店舗を登録できない() throws Exception {
-        mockMvc.perform(post("/admin/restaurants/create").with(user("user").roles("FREE_MEMBER")))
+        mockMvc.perform(post("/admin/restaurants/create").with(user("user").roles("FREE_MEMBER")).with(csrf()))
                 .andExpect(status().isForbidden());
     }
 
@@ -198,6 +199,7 @@ class AdminRestaurantControllerTest {
         when(adminRestaurantService.isValidBusinessHours(any(), any())).thenReturn(true);
 
         mockMvc.perform(multipart("/admin/restaurants/create")
+                        .with(csrf())
                         .with(user("admin").roles("ADMIN"))
                         .param("name", "name")
                         .param("description", "desc")
@@ -264,7 +266,7 @@ class AdminRestaurantControllerTest {
     @Test
     @DisplayName("未ログインの場合は店舗を更新せずにログインページにリダイレクトする")
     void 未ログインの店舗更新はログインにリダイレクト() throws Exception {
-        mockMvc.perform(post("/admin/restaurants/1/update"))
+        mockMvc.perform(post("/admin/restaurants/1/update").with(csrf()))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrlPattern("**/login"));
     }
@@ -272,7 +274,7 @@ class AdminRestaurantControllerTest {
     @Test
     @DisplayName("一般ユーザーは店舗を更新できず403エラー")
     void 一般ユーザーは店舗を更新できない() throws Exception {
-        mockMvc.perform(post("/admin/restaurants/1/update").with(user("user").roles("FREE_MEMBER")))
+        mockMvc.perform(post("/admin/restaurants/1/update").with(user("user").roles("FREE_MEMBER")).with(csrf()))
                 .andExpect(status().isForbidden());
     }
 
@@ -283,6 +285,7 @@ class AdminRestaurantControllerTest {
                 .thenReturn(Restaurant.builder().id(1L).build());
 
         mockMvc.perform(multipart("/admin/restaurants/1/update")
+                        .with(csrf())
                         .with(user("admin").roles("ADMIN"))
                         .param("name", "name")
                         .param("description", "desc")
@@ -303,7 +306,7 @@ class AdminRestaurantControllerTest {
     @Test
     @DisplayName("未ログインの場合は店舗を削除せずにログインページにリダイレクトする")
     void 未ログインの店舗削除はログインにリダイレクト() throws Exception {
-        mockMvc.perform(post("/admin/restaurants/1/delete"))
+        mockMvc.perform(post("/admin/restaurants/1/delete").with(csrf()))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrlPattern("**/login"));
     }
@@ -311,14 +314,14 @@ class AdminRestaurantControllerTest {
     @Test
     @DisplayName("一般ユーザーは店舗を削除できず403エラー")
     void 一般ユーザーは店舗を削除できない() throws Exception {
-        mockMvc.perform(post("/admin/restaurants/1/delete").with(user("user").roles("FREE_MEMBER")))
+        mockMvc.perform(post("/admin/restaurants/1/delete").with(user("user").roles("FREE_MEMBER")).with(csrf()))
                 .andExpect(status().isForbidden());
     }
 
     @Test
     @DisplayName("管理者は店舗削除後に一覧ページへリダイレクトされる")
     void 管理者は店舗削除後に一覧ページへリダイレクトされる() throws Exception {
-        mockMvc.perform(post("/admin/restaurants/1/delete").with(user("admin").roles("ADMIN")))
+        mockMvc.perform(post("/admin/restaurants/1/delete").with(user("admin").roles("ADMIN")).with(csrf()))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/admin/restaurants"));
     }

--- a/src/test/java/com/example/nagoyameshi/controller/admin/AdminTermControllerTest.java
+++ b/src/test/java/com/example/nagoyameshi/controller/admin/AdminTermControllerTest.java
@@ -3,6 +3,7 @@ package com.example.nagoyameshi.controller.admin;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
@@ -111,7 +112,7 @@ class AdminTermControllerTest {
     @Test
     @DisplayName("未ログインの場合は利用規約を更新できずログインページにリダイレクトされる")
     void 未ログインの規約更新はログインにリダイレクト() throws Exception {
-        mockMvc.perform(post("/admin/terms/update"))
+        mockMvc.perform(post("/admin/terms/update").with(csrf()))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrlPattern("**/login"));
     }
@@ -119,7 +120,7 @@ class AdminTermControllerTest {
     @Test
     @DisplayName("一般ユーザーは利用規約を更新できず403エラー")
     void 一般ユーザーは規約更新できない() throws Exception {
-        mockMvc.perform(post("/admin/terms/update").with(user("user").roles("FREE_MEMBER")))
+        mockMvc.perform(post("/admin/terms/update").with(user("user").roles("FREE_MEMBER")).with(csrf()))
                 .andExpect(status().isForbidden());
     }
 
@@ -130,6 +131,7 @@ class AdminTermControllerTest {
                 .thenReturn(Term.builder().id(1L).build());
 
         mockMvc.perform(post("/admin/terms/update")
+                        .with(csrf())
                         .with(user("admin").roles("ADMIN"))
                         .param("content", "text"))
                 .andExpect(status().is3xxRedirection())


### PR DESCRIPTION
## Summary
- enable CSRF by default in `WebSecurityConfig`
- add hidden CSRF token field to reviews page
- update controller tests to send CSRF tokens

## Testing
- `mvn test`


------
https://chatgpt.com/codex/tasks/task_e_685a3f963a5c83278c97c9cc79628bd1