### PR TITLE
Add public company and terms pages

### DIFF
--- a/src/main/java/com/example/nagoyameshi/controller/CompanyController.java
+++ b/src/main/java/com/example/nagoyameshi/controller/CompanyController.java
@@ -1,0 +1,38 @@
+package com.example.nagoyameshi.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import com.example.nagoyameshi.entity.Company;
+import com.example.nagoyameshi.repository.CompanyRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 会員向けの会社概要ページを表示するコントローラ。
+ * 最新の会社情報を取得してビューへ渡すだけのシンプルな処理を行う。
+ */
+@Controller
+@RequiredArgsConstructor
+public class CompanyController {
+
+    /** データベースアクセス用のリポジトリ */
+    private final CompanyRepository companyRepository;
+
+    /**
+     * 会社概要ページを表示する。
+     * 未ログインでも閲覧可能なページのため、アクセス制御は {@link com.example.nagoyameshi.security.WebSecurityConfig} で行う。
+     *
+     * @param model ビューへ値を渡すモデル
+     * @return テンプレート名
+     */
+    @GetMapping("/company")
+    public String index(Model model) {
+        // ID の降順で1件だけ取得。存在しない場合は空の Company を渡す。
+        Company company = companyRepository.findFirstByOrderByIdDesc()
+                .orElse(new Company());
+        model.addAttribute("company", company);
+        return "company/index";
+    }
+}

--- a/src/main/java/com/example/nagoyameshi/controller/TermController.java
+++ b/src/main/java/com/example/nagoyameshi/controller/TermController.java
@@ -1,0 +1,36 @@
+package com.example.nagoyameshi.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import com.example.nagoyameshi.entity.Term;
+import com.example.nagoyameshi.repository.TermRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 会員向けの利用規約ページを表示するコントローラ。
+ */
+@Controller
+@RequiredArgsConstructor
+public class TermController {
+
+    /** データベースアクセス用のリポジトリ */
+    private final TermRepository termRepository;
+
+    /**
+     * 利用規約ページを表示する。
+     *
+     * @param model ビューへ渡すモデル
+     * @return テンプレート名
+     */
+    @GetMapping("/terms")
+    public String index(Model model) {
+        // 最新の利用規約を1件取得し、存在しない場合は空の Term を渡す
+        Term term = termRepository.findFirstByOrderByIdDesc()
+                .orElse(new Term());
+        model.addAttribute("term", term);
+        return "terms/index";
+    }
+}

--- a/src/main/java/com/example/nagoyameshi/security/WebSecurityConfig.java
+++ b/src/main/java/com/example/nagoyameshi/security/WebSecurityConfig.java
@@ -55,6 +55,9 @@ public class WebSecurityConfig {
                                 "/subscription/cancel",
                                 "/subscription/delete")
                             .hasRole("PAID_MEMBER")
+                        // 会社概要・利用規約ページは誰でも閲覧可能 (管理者を除く)
+                        .requestMatchers("/company", "/terms")
+                            .hasAnyRole("ANONYMOUS", "FREE_MEMBER", "PAID_MEMBER")
                         // 予約機能はログイン会員のみ
                         .requestMatchers("/reservations/**", "/restaurants/*/reservations/**")
                             .hasAnyRole("FREE_MEMBER", "PAID_MEMBER")

--- a/src/test/java/com/example/nagoyameshi/controller/CompanyControllerTest.java
+++ b/src/test/java/com/example/nagoyameshi/controller/CompanyControllerTest.java
@@ -1,0 +1,85 @@
+package com.example.nagoyameshi.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.example.nagoyameshi.entity.Company;
+import com.example.nagoyameshi.repository.CompanyRepository;
+import com.example.nagoyameshi.security.UserDetailsImpl;
+import com.example.nagoyameshi.security.UserDetailsServiceImpl;
+import com.example.nagoyameshi.security.WebSecurityConfig;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import java.util.List;
+
+/**
+ * {@link CompanyController} のアクセス制御と表示を検証するテストクラス。
+ */
+@WebMvcTest(CompanyController.class)
+@Import(WebSecurityConfig.class)
+@AutoConfigureMockMvc
+class CompanyControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CompanyRepository companyRepository;
+
+    @MockitoBean
+    private UserDetailsServiceImpl userDetailsService;
+
+    @Test
+    @DisplayName("未ログインでも会社概要ページが表示できる")
+    void 未ログインでも会社概要ページが表示できる() throws Exception {
+        when(companyRepository.findFirstByOrderByIdDesc())
+                .thenReturn(Optional.of(Company.builder().id(1L).build()));
+
+        mockMvc.perform(get("/company"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("company/index"));
+    }
+
+    @Test
+    @DisplayName("一般ユーザーは会社概要ページを表示できる")
+    void 一般ユーザーは会社概要ページを表示できる() throws Exception {
+        when(companyRepository.findFirstByOrderByIdDesc())
+                .thenReturn(Optional.of(Company.builder().id(1L).build()));
+
+        // テスト用のユーザー情報を用意し、アプリと同じ UserDetailsImpl を生成する
+        var userEntity = com.example.nagoyameshi.entity.User.builder()
+                .id(1L)
+                .name("侍 太郎")
+                .email("taro.samurai@example.com")
+                .build();
+        UserDetailsImpl principal = new UserDetailsImpl(userEntity,
+                List.of(new SimpleGrantedAuthority("ROLE_FREE_MEMBER")));
+
+        mockMvc.perform(get("/company").with(user(principal)))
+                .andExpect(status().isOk())
+                .andExpect(view().name("company/index"));
+    }
+
+    @Test
+    @DisplayName("管理者が会社概要ページにアクセスすると403エラー")
+    void 管理者は会社概要ページを閲覧できない() throws Exception {
+        when(companyRepository.findFirstByOrderByIdDesc())
+                .thenReturn(Optional.of(Company.builder().id(1L).build()));
+
+        mockMvc.perform(get("/company").with(user("hanako.samurai@example.com").roles("ADMIN")))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/src/test/java/com/example/nagoyameshi/controller/TermControllerTest.java
+++ b/src/test/java/com/example/nagoyameshi/controller/TermControllerTest.java
@@ -1,0 +1,85 @@
+package com.example.nagoyameshi.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.example.nagoyameshi.entity.Term;
+import com.example.nagoyameshi.repository.TermRepository;
+import com.example.nagoyameshi.security.UserDetailsImpl;
+import com.example.nagoyameshi.security.UserDetailsServiceImpl;
+import com.example.nagoyameshi.security.WebSecurityConfig;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import java.util.List;
+
+/**
+ * {@link TermController} のアクセス制御と表示を検証するテストクラス。
+ */
+@WebMvcTest(TermController.class)
+@Import(WebSecurityConfig.class)
+@AutoConfigureMockMvc
+class TermControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private TermRepository termRepository;
+
+    @MockitoBean
+    private UserDetailsServiceImpl userDetailsService;
+
+    @Test
+    @DisplayName("未ログインでも利用規約ページが表示できる")
+    void 未ログインでも利用規約ページが表示できる() throws Exception {
+        when(termRepository.findFirstByOrderByIdDesc())
+                .thenReturn(Optional.of(Term.builder().id(1L).build()));
+
+        mockMvc.perform(get("/terms"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("terms/index"));
+    }
+
+    @Test
+    @DisplayName("一般ユーザーは利用規約ページを表示できる")
+    void 一般ユーザーは利用規約ページを表示できる() throws Exception {
+        when(termRepository.findFirstByOrderByIdDesc())
+                .thenReturn(Optional.of(Term.builder().id(1L).build()));
+
+        // テスト用のユーザー情報で UserDetailsImpl を生成する
+        var userEntity = com.example.nagoyameshi.entity.User.builder()
+                .id(1L)
+                .name("侍 太郎")
+                .email("taro.samurai@example.com")
+                .build();
+        UserDetailsImpl principal = new UserDetailsImpl(userEntity,
+                List.of(new SimpleGrantedAuthority("ROLE_FREE_MEMBER")));
+
+        mockMvc.perform(get("/terms").with(user(principal)))
+                .andExpect(status().isOk())
+                .andExpect(view().name("terms/index"));
+    }
+
+    @Test
+    @DisplayName("管理者が利用規約ページにアクセスすると403エラー")
+    void 管理者は利用規約ページを閲覧できない() throws Exception {
+        when(termRepository.findFirstByOrderByIdDesc())
+                .thenReturn(Optional.of(Term.builder().id(1L).build()));
+
+        mockMvc.perform(get("/terms").with(user("hanako.samurai@example.com").roles("ADMIN")))
+                .andExpect(status().isForbidden());
+    }
+}


### PR DESCRIPTION
## Summary
- implement `CompanyController` and `TermController`
- update security config to allow access for non-admin users
- add corresponding controller tests

## Testing
- `mvn -DskipTests=false test`


------
https://chatgpt.com/codex/tasks/task_e_685a79f20f1883279091768a2c4e3d9a