### PR TITLE
Add admin dashboard and tests

### DIFF
--- a/src/main/java/com/example/nagoyameshi/controller/AdminHomeController.java
+++ b/src/main/java/com/example/nagoyameshi/controller/AdminHomeController.java
@@ -1,0 +1,51 @@
+package com.example.nagoyameshi.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import com.example.nagoyameshi.service.ReservationService;
+import com.example.nagoyameshi.service.RestaurantService;
+import com.example.nagoyameshi.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 管理者ダッシュボードを表示するコントローラ。
+ */
+@Controller
+@RequiredArgsConstructor
+public class AdminHomeController {
+
+    /** ユーザー関連サービス */
+    private final UserService userService;
+    /** 店舗関連サービス */
+    private final RestaurantService restaurantService;
+    /** 予約関連サービス */
+    private final ReservationService reservationService;
+
+    /**
+     * 管理者トップページを表示する。
+     *
+     * @param model ビューへ渡すモデル
+     * @return テンプレート名
+     */
+    @GetMapping("/admin")
+    public String index(Model model) {
+        long free = userService.countUsersByRole_Name("ROLE_FREE_MEMBER");
+        long paid = userService.countUsersByRole_Name("ROLE_PAID_MEMBER");
+        long total = free + paid;
+        long restaurants = restaurantService.countRestaurants();
+        long reservations = reservationService.countReservations();
+        long sales = paid * 300;
+
+        model.addAttribute("totalFreeMembers", free);
+        model.addAttribute("totalPaidMembers", paid);
+        model.addAttribute("totalMembers", total);
+        model.addAttribute("totalRestaurants", restaurants);
+        model.addAttribute("totalReservations", reservations);
+        model.addAttribute("salesForThisMonth", sales);
+
+        return "admin/index";
+    }
+}

--- a/src/main/java/com/example/nagoyameshi/controller/HomeController.java
+++ b/src/main/java/com/example/nagoyameshi/controller/HomeController.java
@@ -38,6 +38,17 @@ public class HomeController {
 
     @GetMapping("/")
     public String index(Model model) {
+        // 管理者としてログインしている場合は管理画面へリダイレクト
+        var auth = org.springframework.security.core.context.SecurityContextHolder
+                .getContext().getAuthentication();
+        if (auth != null && auth.isAuthenticated()
+                && !(auth instanceof org.springframework.security.authentication.AnonymousAuthenticationToken)) {
+            var user = userService.findUserByEmail(auth.getName());
+            if (user != null && "ROLE_ADMIN".equals(user.getRole().getName())) {
+                return "redirect:/admin";
+            }
+        }
+
         // 評価が高い店舗: レビュー平均点の高い順に6件取得
         var highlyRatedRestaurants = restaurantService
                 .findAllRestaurantsByOrderByAverageScoreDesc(PageRequest.of(0, 6))

--- a/src/main/java/com/example/nagoyameshi/repository/UserRepository.java
+++ b/src/main/java/com/example/nagoyameshi/repository/UserRepository.java
@@ -32,4 +32,12 @@ public interface UserRepository extends JpaRepository<User, Long> {
             String name,
             String furigana,
             Pageable pageable);
+
+    /**
+     * 指定したロール名を持つユーザーの数を返します。
+     *
+     * @param roleName 取得したいロール名
+     * @return 該当ユーザー数
+     */
+    long countByRole_Name(String roleName);
 }

--- a/src/main/java/com/example/nagoyameshi/service/RestaurantService.java
+++ b/src/main/java/com/example/nagoyameshi/service/RestaurantService.java
@@ -80,6 +80,9 @@ public interface RestaurantService {
     Page<Restaurant> findRestaurantsByLowestPriceLessThanEqualOrderByAverageScoreDesc(Integer price,
             Pageable pageable);
 
+    /** 全店舗数を取得する。 */
+    long countRestaurants();
+
     /** 予約数の多い順で全店舗を取得する。 */
     Page<Restaurant> findAllRestaurantsOrderByReservationCountDesc(Pageable pageable);
 

--- a/src/main/java/com/example/nagoyameshi/service/RestaurantServiceImpl.java
+++ b/src/main/java/com/example/nagoyameshi/service/RestaurantServiceImpl.java
@@ -149,4 +149,10 @@ public class RestaurantServiceImpl implements RestaurantService {
     public java.util.Optional<Restaurant> findRestaurantById(Long id) {
         return restaurantRepository.findById(id);
     }
+
+    /** {@inheritDoc} */
+    @Override
+    public long countRestaurants() {
+        return restaurantRepository.count();
+    }
 }

--- a/src/main/java/com/example/nagoyameshi/service/UserService.java
+++ b/src/main/java/com/example/nagoyameshi/service/UserService.java
@@ -97,6 +97,14 @@ public interface UserService {
     void updateRole(User user, String roleName);
 
     /**
+     * ロール名から該当ユーザー数を取得する。
+     *
+     * @param roleName カウントしたいロール名
+     * @return ユーザー数
+     */
+    long countUsersByRole_Name(String roleName);
+
+    /**
      * ロール変更後に現在の認証情報を更新する。
      *
      * @param newRole 新しいロール名

--- a/src/main/java/com/example/nagoyameshi/service/UserServiceImpl.java
+++ b/src/main/java/com/example/nagoyameshi/service/UserServiceImpl.java
@@ -175,6 +175,12 @@ public class UserServiceImpl implements UserService {
 
     /** {@inheritDoc} */
     @Override
+    public long countUsersByRole_Name(String roleName) {
+        return userRepository.countByRole_Name(roleName);
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public void refreshAuthenticationByRole(String newRole) {
         org.springframework.security.core.Authentication current =
                 org.springframework.security.core.context.SecurityContextHolder

--- a/src/test/java/com/example/nagoyameshi/controller/AdminHomeControllerTest.java
+++ b/src/test/java/com/example/nagoyameshi/controller/AdminHomeControllerTest.java
@@ -1,0 +1,75 @@
+package com.example.nagoyameshi.controller;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.example.nagoyameshi.security.UserDetailsServiceImpl;
+import com.example.nagoyameshi.security.WebSecurityConfig;
+import com.example.nagoyameshi.service.ReservationService;
+import com.example.nagoyameshi.service.RestaurantService;
+import com.example.nagoyameshi.service.UserService;
+
+/**
+ * {@link AdminHomeController} の表示処理を検証するテスト。
+ */
+@WebMvcTest(AdminHomeController.class)
+@Import(WebSecurityConfig.class)
+@AutoConfigureMockMvc
+class AdminHomeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UserService userService;
+
+    @MockitoBean
+    private RestaurantService restaurantService;
+
+    @MockitoBean
+    private ReservationService reservationService;
+
+    @MockitoBean
+    private UserDetailsServiceImpl userDetailsService;
+
+    @Test
+    @DisplayName("未ログインの場合は管理画面からログインページにリダイレクトされる")
+    void 未ログインの管理画面アクセスはログインにリダイレクト() throws Exception {
+        mockMvc.perform(get("/admin"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("**/login"));
+    }
+
+    @Test
+    @DisplayName("一般ユーザーは管理画面にアクセスすると403エラー")
+    void 一般ユーザーは管理画面にアクセスできない() throws Exception {
+        mockMvc.perform(get("/admin").with(user("user").roles("FREE_MEMBER")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("管理者は管理画面を閲覧できる")
+    void 管理者は管理画面を閲覧できる() throws Exception {
+        // 各カウント処理は0を返すようにモック
+        org.mockito.Mockito.when(userService.countUsersByRole_Name(org.mockito.ArgumentMatchers.anyString()))
+                .thenReturn(0L);
+        org.mockito.Mockito.when(restaurantService.countRestaurants()).thenReturn(0L);
+        org.mockito.Mockito.when(reservationService.countReservations()).thenReturn(0L);
+
+        mockMvc.perform(get("/admin").with(user("admin").roles("ADMIN")))
+                .andExpect(status().isOk())
+                .andExpect(view().name("admin/index"));
+    }
+}


### PR DESCRIPTION
## Summary
- count users by role in UserRepository
- expose counting method via UserService
- add count functionality to RestaurantService
- create AdminHomeController for admin dashboard
- redirect admins to `/admin` from HomeController
- add tests for AdminHomeController

## Testing
- `./mvnw test -DskipTests=false`

------
https://chatgpt.com/codex/tasks/task_e_685a9221cd648327bfefa2caa0fb9f59