### PR TITLE
Fix admin forms CSRF issue

### DIFF
--- a/src/main/resources/templates/admin/categories/index.html
+++ b/src/main/resources/templates/admin/categories/index.html
@@ -91,6 +91,8 @@
                     </div>
                     <div class="modal-body">
                         <form method="post" th:action="@{/admin/categories/create}" th:object="${categoryRegisterForm}">
+                            <!-- CSRFトークンで不正なリクエストを防止する -->
+                            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                             <div class="form-group mb-3">
                                 <label for="name" class="col-form-label fw-bold">カテゴリ名</label>
                                 <div th:if="${#fields.hasErrors('name')}" class="text-danger small mb-2" th:errors="*{name}"></div>
@@ -114,6 +116,8 @@
                     </div>
                     <div class="modal-body">
                         <form method="post" th:action="@{/admin/categories/0/update}" th:object="${categoryEditForm}">
+                            <!-- CSRFトークンで不正なリクエストを防止する -->
+                            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                             <div class="form-group mb-3">
                                 <label for="editName" class="col-form-label fw-bold">カテゴリ名</label>
                                 <div th:if="${#fields.hasErrors('name')}" class="text-danger small mb-2" th:errors="*{name}"></div>
@@ -140,6 +144,8 @@
                     </div>
                     <div class="modal-footer">
                         <form method="post" th:action="@{/admin/categories/0/delete}">
+                            <!-- CSRFトークンで不正なリクエストを防止する -->
+                            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                             <button type="submit" class="btn text-white shadow-sm nagoyameshi-btn-danger">削除</button>
                         </form>
                     </div>

--- a/src/main/resources/templates/admin/company/edit.html
+++ b/src/main/resources/templates/admin/company/edit.html
@@ -31,6 +31,8 @@
                                     <hr class="mb-4">
 
                                     <form method="post" th:action="@{/admin/company/update}" th:object="${companyEditForm}">
+                                        <!-- CSRFトークンで不正なリクエストを防止する -->
+                                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                                         <div class="form-group row mb-3">
                                             <label for="name" class="col-md-5 col-form-label text-md-left fw-bold">会社名</label>
 

--- a/src/main/resources/templates/admin/restaurants/edit.html
+++ b/src/main/resources/templates/admin/restaurants/edit.html
@@ -32,6 +32,8 @@
                                     <hr class="mb-4">
 
                                     <form method="post" th:action="@{/admin/restaurants/__${restaurant.id}__/update}" th:object="${restaurantEditForm}" enctype="multipart/form-data">
+                                        <!-- CSRFトークンを含めることで、悪意あるリクエストから保護する -->
+                                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                                         <div class="form-group row mb-3">
                                             <label for="name" class="col-md-5 col-form-label text-md-left fw-bold">店舗名</label>
 

--- a/src/main/resources/templates/admin/restaurants/register.html
+++ b/src/main/resources/templates/admin/restaurants/register.html
@@ -31,6 +31,8 @@
                                     <hr class="mb-4">
 
                                     <form method="post" th:action="@{/admin/restaurants/create}" th:object="${restaurantRegisterForm}" enctype="multipart/form-data">
+                                        <!-- CSRFトークンを含めることで、悪意あるリクエストから保護する -->
+                                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                                         <div class="form-group row mb-3">
                                             <label for="name" class="col-md-5 col-form-label text-md-left fw-bold">店舗名</label>
 

--- a/src/main/resources/templates/admin/restaurants/show.html
+++ b/src/main/resources/templates/admin/restaurants/show.html
@@ -26,6 +26,8 @@
                                     </div>
                                     <div class="modal-footer">
                                         <form method="post"th:action="@{/admin/restaurants/__${restaurant.id}__/delete}">
+                                            <!-- CSRFトークンを含めることで、悪意あるリクエストから保護する -->
+                                            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                                             <button type="submit" class="btn text-white shadow-sm nagoyameshi-btn-danger">削除</button>
                                         </form>
                                     </div>

--- a/src/main/resources/templates/admin/terms/edit.html
+++ b/src/main/resources/templates/admin/terms/edit.html
@@ -31,6 +31,8 @@
                                     <hr class="mb-4">
 
                                     <form method="post" th:action="@{/admin/terms/update}" th:object="${termEditForm}">
+                                        <!-- CSRFトークンで不正なリクエストを防止する -->
+                                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                                         <div class="form-group mb-3">
                                             <div th:if="${#fields.hasErrors('content')}" class="text-danger small mb-2" th:errors="*{content}"></div>
                                             <textarea class="form-control" th:field="*{content}" cols="30" rows="24"></textarea>


### PR DESCRIPTION
## Summary
- insert CSRF tokens in admin register/edit/delete forms
- protect admin company, terms and categories forms

## Testing
- `mvn -DskipTests package`
- `mvn test` *(fails: log incomplete)*

------
https://chatgpt.com/codex/tasks/task_e_685d043f95608327a8f25e7f513316ae