### PR TITLE
Add logging for MultipartConfig and unit test to verify bean

### DIFF
--- a/src/main/java/com/example/nagoyameshi/config/MultipartConfig.java
+++ b/src/main/java/com/example/nagoyameshi/config/MultipartConfig.java
@@ -4,6 +4,10 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.multipart.support.MultipartFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.annotation.PostConstruct;
 
 /**
  * multipart/form-data のリクエストをセキュリティフィルタより前に
@@ -12,6 +16,19 @@ import org.springframework.web.multipart.support.MultipartFilter;
  */
 @Configuration
 public class MultipartConfig {
+
+    /** Logger for this class */
+    private static final Logger log = LoggerFactory.getLogger(MultipartConfig.class);
+
+    /**
+     * Called after bean creation to confirm that this configuration class
+     * is loaded when the application starts.
+     */
+    @PostConstruct
+    public void init() {
+        // 出力内容は起動ログで確認可能
+        log.info("MultipartConfig has been loaded");
+    }
 
     /**
      * MultipartFilter を登録し、Spring Security より前に実行させます。

--- a/src/test/java/com/example/nagoyameshi/config/MultipartConfigTest.java
+++ b/src/test/java/com/example/nagoyameshi/config/MultipartConfigTest.java
@@ -1,0 +1,33 @@
+package com.example.nagoyameshi.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.web.multipart.support.MultipartFilter;
+
+/**
+ * {@link MultipartConfig} がアプリケーション起動時に正しく読み込まれるかを検証するテスト。
+ */
+@SpringBootTest
+class MultipartConfigTest {
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Autowired
+    private FilterRegistrationBean<MultipartFilter> multipartFilter;
+
+    @Test
+    @DisplayName("multipartFilter Bean がコンテキストに登録されている")
+    void multipartFilter_Beanが登録されている() {
+        // Bean 名を指定して存在するか確認
+        assertThat(context.containsBean("multipartFilter")).isTrue();
+        // Bean のインスタンスも null でないことを確認
+        assertThat(multipartFilter).isNotNull();
+    }
+}


### PR DESCRIPTION
## Summary
- add a log in `MultipartConfig` to confirm the configuration is loaded
- create `MultipartConfigTest` to ensure the `multipartFilter` bean is present

## Testing
- `./mvnw test`

------
https://chatgpt.com/codex/tasks/task_e_685e4526e8c48327b024413dba865c36