### PR TITLE
Add CSRF toggle property

### DIFF
--- a/src/main/java/com/example/nagoyameshi/security/WebSecurityConfig.java
+++ b/src/main/java/com/example/nagoyameshi/security/WebSecurityConfig.java
@@ -3,6 +3,7 @@ package com.example.nagoyameshi.security;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.config.Customizer;
@@ -24,6 +25,14 @@ public class WebSecurityConfig {
     private final UserDetailsServiceImpl userDetailsService;
 
     /**
+     * CSRF保護の有効・無効を切り替えるフラグです。
+     * application.properties の security.enable-csrf で設定できます。
+     * true を設定すると CSRF 保護が有効になります。
+     */
+    @Value("${security.enable-csrf:true}")
+    private boolean enableCsrf;
+
+    /**
      * アプリ全体のセキュリティフィルタチェーンを構成します。
      *
      * @param http HttpSecurity の設定オブジェクト
@@ -32,9 +41,15 @@ public class WebSecurityConfig {
      */
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        // CSRF を有効にするかどうかはプロパティで切り替え
+        if (enableCsrf) {
+            http.csrf(Customizer.withDefaults());
+        } else {
+            // 一時的に CSRF を無効化する場合はこちらが実行されます
+            http.csrf(csrf -> csrf.disable());
+        }
+
         return http
-                // CSRF 保護を有効化して、すべてのPOSTリクエストを安全に処理
-                .csrf(Customizer.withDefaults())
                 // URL ごとのアクセス許可設定
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,3 +24,5 @@ spring.mail.from=noreply.example.com
 stripe.api-key=sk_test_51RWwNsIDOur3dnQg57xclf6oTzOlbC4KNMHwOqsabzbQ1dkNVR47EGxIXfVWK9dYhigA98tGyyvJAkM8ANIELlTI00NpCjUlok
 stripe.premium-plan-price-id=price_1Rd5NSIDOur3dnQgIA2PJDg4
 
+# -- セキュリティ設定 -------------------------------------
+security.enable-csrf=true


### PR DESCRIPTION
## Summary
- support enabling/disabling CSRF via a configuration property
- document the new `security.enable-csrf` property in `application.properties`

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_685e4b75d5a48327a5d9c72a28065c04